### PR TITLE
One login callback (version 0.5.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,18 @@ Only if you want to know, that will redirect the user to the IDP, and will came 
 ### Log out
 Now there are two ways the user can log out.
  + 1 - By logging out in your app: In this case you 'should' notify the IDP first so it closes global session.
- + 2 - By logging out of the global SSO Session. In this case the IDP will notify you on /saml2/slo enpoint (already provided)
+ + 2 - By logging out of the global SSO Session. In this case the IDP will notify you on /saml2/slo endpoint (already provided)
 
 For case 1 call `Saml2Auth::logout();` or redirect the user to the route 'saml_logout' which does just that. Do not close session inmediately as you need to receive a response confirmation from the IDP (redirection). That response will be handled by the library at /saml2/sls and will fire an event for you to complete the operation.
 
 For case 2 you will only receive the event. Both cases 1 and 2 receive the same event. 
 
+Note that for case 2, you may have to manually save your session to make the logout stick (as the session is saved by middleware, but the OneLogin library will redirect back to your IDP before that happens)
+
 ```php
         Event::listen('Aacotroneo\Saml2\Events\Saml2LogoutEvent', function ($event) {
             Auth::logout();
+            Session::save();
         });
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "keywords": ["laravel","saml", "saml2", "onelogin"],
     "homepage": "https://github.com/aacotroneo/laravel-saml2",
     "license": "MIT",
+    "version": "0.6.0",
     "authors": [
         {
             "name": "aacotroneo",
@@ -13,7 +14,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": ">=5.0.0",
-        "onelogin/php-saml": "2.3"
+        "onelogin/php-saml": "2.6.1"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*"

--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -3,7 +3,6 @@
 namespace Aacotroneo\Saml2\Http\Controllers;
 
 use Aacotroneo\Saml2\Events\Saml2LoginEvent;
-use Aacotroneo\Saml2\Events\Saml2LogoutEvent;
 use Aacotroneo\Saml2\Saml2Auth;
 use Illuminate\Routing\Controller;
 use Config;
@@ -82,7 +81,6 @@ class Saml2Controller extends Controller
             throw new \Exception("Could not log out");
         }
 
-        Event::fire(new Saml2LogoutEvent());
         return Redirect::to(Config::get('saml2::settings.logoutRoute')); //may be set a configurable default
     }
 

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -5,6 +5,7 @@ namespace Aacotroneo\Saml2;
 use OneLogin_Saml2_Auth;
 use OneLogin_Saml2_Error;
 use OneLogin_Saml2_Utils;
+use Aacotroneo\Saml2\Events\Saml2LogoutEvent;
 
 use Log;
 use Psr\Log\InvalidArgumentException;
@@ -99,8 +100,13 @@ class Saml2Auth
     {
         $auth = $this->auth;
 
-        $keep_local_session = true; //we don't touch session here
-        $auth->processSLO($keep_local_session);
+        // destroy the local session by firing the Logout event
+        $keep_local_session = false;
+        $session_callback = function () {
+            \Event::fire(new Saml2LogoutEvent());
+        };
+
+        $auth->processSLO($keep_local_session, null, false, $session_callback);
 
         $errors = $auth->getErrors();
 

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -87,7 +87,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
     {
         $auth = m::mock('OneLogin_Saml2_Auth');
         $saml2 = new Saml2Auth($auth);
-        $auth->shouldReceive('processSLO')->once()->with(true);
+        $auth->shouldReceive('processSLO')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn('errors');
 
         $error =  $saml2->sls();
@@ -99,7 +99,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
     {
         $auth = m::mock('OneLogin_Saml2_Auth');
         $saml2 = new Saml2Auth($auth);
-        $auth->shouldReceive('processSLO')->once()->with(true);
+        $auth->shouldReceive('processSLO')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(null);
 
         $error =  $saml2->sls();


### PR DESCRIPTION
Updated version to 0.5.2

Changes:

* Requires `onelogin/php-saml@v2.6.1`
* Added `"version" : "0.5.2"` to `composer.json`
* `Saml2LoginEvent` is now fired as a callback sent to `processSLO`
* Updated `README.md` to mention that the session may need to be manually saved when the SLO request originates from another SP.