### PR TITLE
Updated logout route to use the correct config file

### DIFF
--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -81,7 +81,7 @@ class Saml2Controller extends Controller
             throw new \Exception("Could not log out");
         }
 
-        return Redirect::to(Config::get('saml2::settings.logoutRoute')); //may be set a configurable default
+        return Redirect::to(config('saml2_settings.logoutRoute')); //may be set a configurable default
     }
 
     /**


### PR DESCRIPTION
Small fix to the Redirect::to as it was using the old way of getting the logout route.