### PR TITLE
allow the route group middleware to be set in the config

### DIFF
--- a/src/config/saml2_settings.php
+++ b/src/config/saml2_settings.php
@@ -13,6 +13,12 @@ return $settings = array(
     'routesPrefix' => '/saml2',
 
     /**
+     * which middleware group to use for the saml routes
+     * Laravel 5.2 will need a group which includes StartSession
+     */
+    'routesMiddleware' => [],
+
+    /**
      * Where to redirect after logout
      */
     'logoutRoute' => '/',

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,7 +1,10 @@
 <?php
 
 
-Route::group(array('prefix' => config('saml2_settings.routesPrefix')), function () {
+Route::group([
+    'prefix' => config('saml2_settings.routesPrefix'),
+    'middleware' => config('saml2_settings.routesMiddleware'),
+], function () {
 
     Route::get('/logout', array(
         'as' => 'saml_logout',


### PR DESCRIPTION
When using Laravel 5.2, I was getting a redirect loop (The same thing was reported in #18 I think), caused by the session not being ready yet because the SessionStart middleware is no longer on by default.

The temprary fix was to turn off the routes in the config, copy them into my application and add the middleware, but a better fix would be if the package routes could use a value pulled from the config, allowing users to specify what they like.