### PR TITLE
replace all facade usage with helper functions

### DIFF
--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -5,12 +5,6 @@ namespace Aacotroneo\Saml2\Http\Controllers;
 use Aacotroneo\Saml2\Events\Saml2LoginEvent;
 use Aacotroneo\Saml2\Saml2Auth;
 use Illuminate\Routing\Controller;
-use Config;
-use Event;
-use Log;
-use Redirect;
-use Response;
-use Session;
 
 
 class Saml2Controller extends Controller
@@ -35,11 +29,8 @@ class Saml2Controller extends Controller
     {
 
         $metadata = $this->saml2Auth->getMetadata();
-        $response = Response::make($metadata, 200);
 
-        $response->header('Content-Type', 'text/xml');
-
-        return $response;
+        return response($metadata, 200, ['Content-Type' => 'text/xml']);
     }
 
     /**
@@ -51,21 +42,21 @@ class Saml2Controller extends Controller
         $errors = $this->saml2Auth->acs();
 
         if (!empty($errors)) {
-            Log::error('Saml2 error', $errors);
-            Session::flash('saml2_error', $errors);
-            return Redirect::to(config('saml2_settings.errorRoute'));
+            logger()->error('Saml2 error', $errors);
+            session()->flash('saml2_error', $errors);
+            return redirect(config('saml2_settings.errorRoute'));
         }
         $user = $this->saml2Auth->getSaml2User();
 
-        Event::fire(new Saml2LoginEvent($user));
+        event(new Saml2LoginEvent($user));
 
         $redirectUrl = $user->getIntendedUrl();
 
         if ($redirectUrl !== null) {
-            return Redirect::to($redirectUrl);
+            return redirect($redirectUrl);
         } else {
 
-            return Redirect::to(config('saml2_settings.loginRoute')); 
+            return redirect(config('saml2_settings.loginRoute'));
         }
     }
 
@@ -81,7 +72,7 @@ class Saml2Controller extends Controller
             throw new \Exception("Could not log out");
         }
 
-        return Redirect::to(config('saml2_settings.logoutRoute')); //may be set a configurable default
+        return redirect(config('saml2_settings.logoutRoute')); //may be set a configurable default
     }
 
     /**

--- a/src/Aacotroneo/Saml2/Saml2User.php
+++ b/src/Aacotroneo/Saml2/Saml2User.php
@@ -47,14 +47,14 @@ class Saml2User
      */
     function getRawSamlAssertion()
     {
-        return Input::get('SAMLResponse'); //just this request
+        return input('SAMLResponse'); //just this request
     }
 
     function getIntendedUrl()
     {
-        $relayState = Input::get('RelayState'); //just this request
+        $relayState = input('RelayState'); //just this request
 
-        if ($relayState && URL::full() !=$relayState) {
+        if ($relayState && url()->full() != $relayState) {
 
             return $relayState;
         }


### PR DESCRIPTION
When I tried to use the package with Laravel 5.2, I came across an error because the `Input` facade is no longer available by default.

When I looked into this, I found the following Laravel issue: https://github.com/laravel/laravel/commit/2adbbbd91e9d6e2d569cc56f138b7273efe25651, which strongly suggests that third party packages should not rely on the existence of facades, so I have replaced all instances of facade calls with calls to the equivalent helper functions.