### PR TITLE
fix missing function input

### DIFF
--- a/src/Aacotroneo/Saml2/Saml2User.php
+++ b/src/Aacotroneo/Saml2/Saml2User.php
@@ -2,9 +2,7 @@
 
 namespace Aacotroneo\Saml2;
 
-use Input;
 use OneLogin_Saml2_Auth;
-use URL;
 
 /**
  * A simple class that represents the user that 'came' inside the saml2 assertion
@@ -47,12 +45,12 @@ class Saml2User
      */
     function getRawSamlAssertion()
     {
-        return input('SAMLResponse'); //just this request
+        return app('request')->input('SAMLResponse'); //just this request
     }
 
     function getIntendedUrl()
     {
-        $relayState = input('RelayState'); //just this request
+        $relayState = app('request')->input('RelayState'); //just this request
 
         if ($relayState && url()->full() != $relayState) {
 


### PR DESCRIPTION
This is a bit embarrassing, but I just noticed the merge request you accepted earlier didn't work :blush: 

I had a bit of a brain fart and used a helper function called `input` which doesn't actually exist. It should be `app('request')->input()`. 

I've fixed this now, sorry for the lack of QA.