### PR TITLE
remove use of event facade

### DIFF
--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -103,7 +103,7 @@ class Saml2Auth
         // destroy the local session by firing the Logout event
         $keep_local_session = false;
         $session_callback = function () {
-            \Event::fire(new Saml2LogoutEvent());
+            event(new Saml2LogoutEvent());
         };
 
         $auth->processSLO($keep_local_session, null, false, $session_callback);


### PR DESCRIPTION
Just noticed I missed one of the facade usages earlier. 

Sorry for bombarding you with pull requests today, I appreciate the swift responses though!