### PR TITLE
Support for Logout to work with ADFS 3.0 as Identity Provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.*",
-        "onelogin/php-saml": "2.3"
+	"illuminate/support": "5.1.*",
+        "onelogin/php-saml": "2.5"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4.0",
 	"illuminate/support": "5.1.*",
-        "onelogin/php-saml": "2.5"
+        "onelogin/php-saml": "2.6"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*"

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -8,6 +8,7 @@ use OneLogin_Saml2_Utils;
 use Aacotroneo\Saml2\Events\Saml2LogoutEvent;
 
 use Log;
+use Session;
 use Psr\Log\InvalidArgumentException;
 
 class Saml2Auth

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -112,7 +112,8 @@ class Saml2Auth
             \Event::fire(new Saml2LogoutEvent());
         };
 
-        $auth->processSLO($keep_local_session, null, false, $session_callback);
+        // Mickael: Changed $retrieveParametersFromServer paramter to true otherwise when the signedQuery is corrupted and the signature validation failed
+        $auth->processSLO($keep_local_session, null, true, $session_callback);
 
         $errors = $auth->getErrors();
 

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -59,11 +59,11 @@ class Saml2Auth
      * Initiate a saml2 logout flow. It will close session on all other SSO services. You should close
      * local session if applicable.
      */
-    function logout()
+    function logout($returnTo = null)
     {
         $auth = $this->auth;
-
-        $auth->logout();
+        $federationData = Session::get('federationData');
+        $auth->logout($returnTo, array(), $federationData['nameId'], $federationData['sessionIndex']);
     }
 
     /**
@@ -83,6 +83,11 @@ class Saml2Auth
         if (!empty($errors)) {
             return $errors;
         }
+
+        Session::put('federationData', [
+            'sessionIndex' => $auth->getSessionIndex(),
+            'nameId' => $auth->getNameId()
+        ]);
 
         if (!$auth->isAuthenticated()) {
             return array('error' => 'Could not authenticate');
@@ -138,4 +143,4 @@ class Saml2Auth
     }
 
 
-} 
+}


### PR DESCRIPTION
The following changes were made to fix Logout . I tested it with ADFS 3.0.

1. I added some code to save in session the NameId and SessionIndex received through the acs url. I use this values in the LogoutRequest in order to logout to work correctly (without it ADFS does not know which is the session participant that is logging out)

2. For some reason, in sls process if the method processSLO is called with the parameter $retrieveParametersFromServer to false, the signature validation of the LogoutResponse fails, if called with true, the signature is correctly validated (I found out that the signedQuery generated by onelogin LogoutResponse class (line 153) differs depending on the $retrieveParametersFromServer parameter). Maybe it would be better to make this parameter configurable.