### PR TITLE
Exposed sessionIndex and nameId to be able to logout correctly

### DIFF
--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -5,6 +5,7 @@ namespace Aacotroneo\Saml2\Http\Controllers;
 use Aacotroneo\Saml2\Events\Saml2LoginEvent;
 use Aacotroneo\Saml2\Saml2Auth;
 use Illuminate\Routing\Controller;
+use Illuminate\Http\Request;
 
 
 class Saml2Controller extends Controller
@@ -78,9 +79,12 @@ class Saml2Controller extends Controller
     /**
      * This initiates a logout request across all the SSO infrastructure.
      */
-    public function logout()
+    public function logout(Request $request)
     {
-        $this->saml2Auth->logout(); //will actually end up in the sls endpoint
+        $returnTo = $request->query('returnTo');
+        $sessionIndex = $request->query('sessionIndex');
+        $nameId = $request->query('nameId');
+        $this->saml2Auth->logout($returnTo, $nameId, $sessionIndex); //will actually end up in the sls endpoint
         //does not return
     }
 

--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -68,7 +68,7 @@ class Saml2Controller extends Controller
      */
     public function sls()
     {
-        $error = $this->saml2Auth->sls();
+        $error = $this->saml2Auth->sls(config('saml2_settings.retrieveParametersFromServer'));
         if (!empty($error)) {
             throw new \Exception("Could not log out");
         }

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -138,4 +138,4 @@ class Saml2Auth
     }
 
 
-} 
+}

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -59,11 +59,11 @@ class Saml2Auth
      * Initiate a saml2 logout flow. It will close session on all other SSO services. You should close
      * local session if applicable.
      */
-    function logout()
+    function logout($returnTo = null, $nameId = null, $sessionIndex = null)
     {
         $auth = $this->auth;
 
-        $auth->logout();
+        $auth->logout($returnTo, [], $nameId, $sessionIndex);
     }
 
     /**

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -96,7 +96,7 @@ class Saml2Auth
      * Process a Saml response (assertion consumer service)
      * returns an array with errors if it can not logout
      */
-    function sls()
+    function sls($retrieveParametersFromServer = false)
     {
         $auth = $this->auth;
 
@@ -106,7 +106,7 @@ class Saml2Auth
             event(new Saml2LogoutEvent());
         };
 
-        $auth->processSLO($keep_local_session, null, false, $session_callback);
+        $auth->processSLO($keep_local_session, null, $retrieveParametersFromServer, $session_callback);
 
         $errors = $auth->getErrors();
 

--- a/src/Aacotroneo/Saml2/Saml2User.php
+++ b/src/Aacotroneo/Saml2/Saml2User.php
@@ -58,4 +58,14 @@ class Saml2User
         }
     }
 
-} 
+    function getSessionIndex()
+    {
+        return $this->auth->getSessionIndex();
+    }
+
+    function getNameId()
+    {
+        return $this->auth->getNameId();
+    }
+
+}

--- a/src/config/saml2_settings.php
+++ b/src/config/saml2_settings.php
@@ -19,6 +19,12 @@ return $settings = array(
     'routesMiddleware' => [],
 
     /**
+     * Indicates how the parameters will be
+     * retrieved from the sls request for signature validation
+     */
+    'retrieveParametersFromServer' => false,
+
+    /**
      * Where to redirect after logout
      */
     'logoutRoute' => '/',

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -37,10 +37,15 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testLogout()
     {
+        $expectedReturnTo = 'http://localhost';
+        $expectedSessionIndex = 'session_index_value';
+        $expectedNameId = 'name_id_value';
         $auth = m::mock('OneLogin_Saml2_Auth');
         $saml2 = new Saml2Auth($auth);
-        $auth->shouldReceive('logout')->with()->once();
-        $saml2->logout();
+        $auth->shouldReceive('logout')
+            ->with($expectedReturnTo, [], $expectedNameId, $expectedSessionIndex)
+            ->once();
+        $saml2->logout($expectedReturnTo, $expectedNameId, $expectedSessionIndex);
     }
 
 
@@ -134,4 +139,4 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 //        $this->assertEquals(2.71, $mock->e());
 
 }
- 
+


### PR DESCRIPTION
Hi,

As we discussed I exposed the sessionIndex and nameId in order to be able to save those values in the  Saml2LoginEvent event, I changed the Saml2Controller and Saml2Auth class to receive the returnUrl, sessionIndex and nameId as parameters and finally I added the retrieveParametersFromServer option in the configuration files.

I tested those changes with my ADFS installation and is all working ok.

Best regards