### PR TITLE
directly call the UrlGenerator binding instead of using the helper

### DIFF
--- a/src/Aacotroneo/Saml2/Saml2User.php
+++ b/src/Aacotroneo/Saml2/Saml2User.php
@@ -52,7 +52,9 @@ class Saml2User
     {
         $relayState = app('request')->input('RelayState'); //just this request
 
-        if ($relayState && url()->full() != $relayState) {
+        $url = app('Illuminate\Contracts\Routing\UrlGenerator');
+
+        if ($relayState && $url->full() != $relayState) {
 
             return $relayState;
         }


### PR DESCRIPTION
Apparently only Laravel 5.2 returns the UrlGenerator from the url helper when you call it with no arguments, this bypasses the helper and fixes that.

It looks like Taylor is deemphasising Facades, so we should stick with the helpers or app bindings where possible, and if in the future we drop support for 5.1 this can be removed in favour of calling `url()->full` again.

Fixes #31 and #32.