### PR TITLE
OneLogin package version changed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": ">=5.0.0",
-        "onelogin/php-saml": "2.9.1"
+        "onelogin/php-saml": "2.*"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*"


### PR DESCRIPTION
This will allow to make php-saml package updates. As it still will be kept within version 2 of the package it shouldn't break functionality.
There is new version of php-saml (2.10) which includes security updates.