### PR TITLE
Ability to completely disable the singleLogoutService

### DIFF
--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -47,7 +47,8 @@ class Saml2ServiceProvider extends ServiceProvider
             if (empty($config['sp']['assertionConsumerService']['url'])) {
                 $config['sp']['assertionConsumerService']['url'] = URL::route('saml_acs');
             }
-            if (empty($config['sp']['singleLogoutService']['url'])) {
+            if (!empty($config['sp']['singleLogoutService']) &&
+                 empty($config['sp']['singleLogoutService']['url'])) {
                 $config['sp']['singleLogoutService']['url'] = URL::route('saml_sls');
             }
 

--- a/src/config/saml2_settings.php
+++ b/src/config/saml2_settings.php
@@ -93,6 +93,7 @@ return $settings = array(
         ),
         // Specifies info about where and how the <Logout Response> message MUST be
         // returned to the requester, in this case our SP.
+        // Remove this part to not include any URL Location in the metadata.
         'singleLogoutService' => array(
             // URL Location where the <Response> from the IdP will be returned,
             // using HTTP-Redirect binding.


### PR DESCRIPTION
The singleLogoutService URL Location can be removed from the metadata by not specifying it in the settings