### PR TITLE
Improve error handling

### DIFF
--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -43,6 +43,9 @@ class Saml2Controller extends Controller
         $errors = $this->saml2Auth->acs();
 
         if (!empty($errors)) {
+            logger()->error('Saml2 error_detail', ['error' => $this->saml2Auth->getLastErrorReason()]);
+            session()->flash('saml2_error_detail', [$this->saml2Auth->getLastErrorReason()]);
+
             logger()->error('Saml2 error', $errors);
             session()->flash('saml2_error', $errors);
             return redirect(config('saml2_settings.errorRoute'));

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -137,5 +137,12 @@ class Saml2Auth
         }
     }
 
-
+    /**
+     * Get the last error reason from \OneLogin_Saml2_Auth, useful for error debugging.
+     * @see \OneLogin_Saml2_Auth::getLastErrorReason()
+     * @return string
+     */
+    function getLastErrorReason() {
+        return $this->auth->getLastErrorReason();
+    }
 }

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -112,6 +112,16 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($error);
     }
 
+    public function testCanGetLastError()
+    {
+        $auth = m::mock('OneLogin_Saml2_Auth');
+        $saml2 = new Saml2Auth($auth);
+
+        $auth->shouldReceive('getLastErrorReason')->andReturn('lastError');
+
+        $this->assertSame('lastError', $saml2->getLastErrorReason());
+    }
+
 /**
          * Cant test here. It uses Laravel dependencies (eg. config())
          */


### PR DESCRIPTION
- Expose the last error reason from the underlying saml lib to consumers of this package
- Log the last error reason and flash to session in the default saml controller

Fixes #38 