### PR TITLE
Add support for trusting proxy vars

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": ">=5.0.0",
-        "onelogin/php-saml": "2.*"
+        "onelogin/php-saml": "^2.10"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*"

--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -29,6 +29,10 @@ class Saml2ServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../../config/saml2_settings.php' => config_path('saml2_settings.php'),
         ]);
+
+        if (config('saml2_settings.proxyVars', false)) {
+            \OneLogin_Saml2_Utils::setProxyVars(true);
+        }
     }
 
     /**

--- a/src/config/saml2_settings.php
+++ b/src/config/saml2_settings.php
@@ -64,7 +64,13 @@ return $settings = array(
     'strict' => true, //@todo: make this depend on laravel config
 
     // Enable debug mode (to print errors)
-    'debug' => false, //@todo: make this depend on laravel config
+    'debug' => false, //@todo: make this depend on laravel config,
+
+    // If 'proxyVars' is True, then the Saml lib will trust proxy headers
+    // e.g X-Forwarded-Proto / HTTP_X_FORWARDED_PROTO. This is useful if
+    // your application is running behind a load balancer which terminates
+    // SSL.
+    'proxyVars' => false,
 
     // Service Provider Data that we are deploying
     'sp' => array(


### PR DESCRIPTION
This allows consumers to run behind a load balancer which is terminating SSL. Moves requirement of OneLogin lib to ^2.10 as this is when they stopped trusting by default