### PR TITLE
Allow to set the nameIdFormat when calling the logout method.

### DIFF
--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -59,11 +59,11 @@ class Saml2Auth
      * Initiate a saml2 logout flow. It will close session on all other SSO services. You should close
      * local session if applicable.
      */
-    function logout($returnTo = null, $nameId = null, $sessionIndex = null)
+    function logout($returnTo = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null)
     {
         $auth = $this->auth;
 
-        $auth->logout($returnTo, [], $nameId, $sessionIndex);
+        $auth->logout($returnTo, [], $nameId, $sessionIndex, false, $nameIdFormat);
     }
 
     /**

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -40,12 +40,13 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
         $expectedReturnTo = 'http://localhost';
         $expectedSessionIndex = 'session_index_value';
         $expectedNameId = 'name_id_value';
+        $expectedNameIdFormat = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified';
         $auth = m::mock('OneLogin_Saml2_Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('logout')
-            ->with($expectedReturnTo, [], $expectedNameId, $expectedSessionIndex)
+            ->with($expectedReturnTo, [], $expectedNameId, $expectedSessionIndex, false, $expectedNameIdFormat)
             ->once();
-        $saml2->logout($expectedReturnTo, $expectedNameId, $expectedSessionIndex);
+        $saml2->logout($expectedReturnTo, $expectedNameId, $expectedSessionIndex, $expectedNameIdFormat);
     }
 
 


### PR DESCRIPTION
Hi, I've read in some of the Issues or Pull requests that the library aims to be easy to use and thus might lack some configurations on purpose.
I think that allowing to set the `nameIdFormat` when requesting a logout doesn't add too much complexity but can come in handy.

I'm creating this pull request to fix an issue I'm having with the logout process.