### PR TITLE
Make Auth object and LastMessageID available through Saml2LoginEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ The Saml2::login will redirect the user to the IDP and will came back to an endp
 ```php
 
  Event::listen('Aacotroneo\Saml2\Events\Saml2LoginEvent', function (Saml2LoginEvent $event) {
-
+            $messageId = $event->getSaml2Auth()->getLastMessageId();
+            // your own code preventing reuse of a $messageId to stop replay attacks
             $user = $event->getSaml2User();
             $userData = [
                 'id' => $user->getUserId(),

--- a/src/Aacotroneo/Saml2/Events/Saml2LoginEvent.php
+++ b/src/Aacotroneo/Saml2/Events/Saml2LoginEvent.php
@@ -2,13 +2,18 @@
 
 namespace Aacotroneo\Saml2\Events;
 
+use Aacotroneo\Saml2\Saml2User;
+use Aacotroneo\Saml2\Saml2Auth;
+
 class Saml2LoginEvent {
 
     protected $user;
+    protected $auth;
 
-    function __construct($user)
+    function __construct(Saml2User $user, Saml2Auth $auth)
     {
         $this->user = $user;
+        $this->auth = $auth;
     }
 
     public function getSaml2User()
@@ -16,6 +21,9 @@ class Saml2LoginEvent {
         return $this->user;
     }
 
-
+    public function getSaml2Auth()
+    {
+        return $this->auth;
+    }
 
 }

--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -52,7 +52,7 @@ class Saml2Controller extends Controller
         }
         $user = $this->saml2Auth->getSaml2User();
 
-        event(new Saml2LoginEvent($user));
+        event(new Saml2LoginEvent($user, $this->saml2Auth));
 
         $redirectUrl = $user->getIntendedUrl();
 

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -45,6 +45,15 @@ class Saml2Auth
     }
 
     /**
+     * The ID of the last message processed
+     * @return String
+     */
+    function getLastMessageId()
+    {
+        return $this->auth->getLastMessageId();
+    }
+
+    /**
      * Initiate a saml2 login flow. It will redirect! Before calling this, check if user is
      * authenticated (here in saml2). That would be true when the assertion was received this request.
      */


### PR DESCRIPTION
This will allow access to the saml message ids for login event listeners and therefore the application to build in protection from Replay Attacks.