### PR TITLE
Add options to parse the attributes easier

### DIFF
--- a/src/Aacotroneo/Saml2/Saml2User.php
+++ b/src/Aacotroneo/Saml2/Saml2User.php
@@ -41,6 +41,18 @@ class Saml2User
     }
 
     /**
+     * Returns the requested SAML attribute
+     *
+     * @param string $name The requested attribute of the user.
+     * @return array|null Requested SAML attribute ($name).
+     */
+    function getAttribute($name) {
+        $auth = $this->auth;
+
+        return $auth->getAttribute($name);
+    }
+
+    /**
      * @return string the saml assertion processed this request
      */
     function getRawSamlAssertion()
@@ -57,6 +69,35 @@ class Saml2User
         if ($relayState && $url->full() != $relayState) {
 
             return $relayState;
+        }
+    }
+
+    /**
+     * Parses a SAML property and adds this property to this user or returns the value
+     *
+     * @param string $samlAttribute
+     * @param string $propertyName
+     * @return array|null
+     */
+    function parseUserAttribute($samlAttribute = null, $propertyName = null) {
+        if(empty($samlAttribute)) {
+            return null;
+        }
+        if(empty($propertyName)) {
+            return $this->getAttribute($samlAttribute);
+        }
+
+        return $this->{$propertyName} = $this->getAttribute($samlAttribute);
+    }
+
+    /**
+     * Parse the saml attributes and adds it to this user
+     *
+     * @param array $attributes Array of properties which need to be parsed, like this ['email' => 'urn:oid:0.9.2342.19200300.100.1.3']
+     */
+    function parseAttributes($attributes = array()) {
+        foreach($attributes as $propertyName => $samlAttribute) {
+            $this->parseUserAttribute($samlAttribute, $propertyName);
         }
     }
 


### PR DESCRIPTION
I made getAttribute function (from OneLogin_Saml2_Auth) also in Saml2User, so you can easily get one SAML attribute.

I also added two functions to easily add the SAML properties to the Saml2User.

For example you can now do this in your event handler:
```php
public function handle(Saml2LoginEvent $event) {
    $user = $event->getSaml2User();
    $user->parseAttributes([
        'email' => 'urn:oid:0.9.2342.19200300.100.1.3',
        'displayName' => 'urn:oid:2.16.840.1.113730.3.1.241'
    ]);
    $emails = $user->email;
}
```