### PR TITLE
Parse attributes tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel","saml", "saml2", "onelogin"],
     "homepage": "https://github.com/aacotroneo/laravel-saml2",
     "license": "MIT",
-    "version": "0.8.1",
+    "version": "0.9.0",
     "authors": [
         {
             "name": "aacotroneo",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel","saml", "saml2", "onelogin"],
     "homepage": "https://github.com/aacotroneo/laravel-saml2",
     "license": "MIT",
-    "version": "0.9.0",
+    "version": "0.9.1",
     "authors": [
         {
             "name": "aacotroneo",

--- a/src/Aacotroneo/Saml2/Saml2User.php
+++ b/src/Aacotroneo/Saml2/Saml2User.php
@@ -41,6 +41,18 @@ class Saml2User
     }
 
     /**
+     * Returns the requested SAML attribute
+     *
+     * @param string $name The requested attribute of the user.
+     * @return array|null Requested SAML attribute ($name).
+     */
+    function getAttribute($name) {
+        $auth = $this->auth;
+
+        return $auth->getAttribute($name);
+    }
+
+    /**
      * @return string the saml assertion processed this request
      */
     function getRawSamlAssertion()
@@ -57,6 +69,35 @@ class Saml2User
         if ($relayState && $url->full() != $relayState) {
 
             return $relayState;
+        }
+    }
+
+    /**
+     * Parses a SAML property and adds this property to this user or returns the value
+     *
+     * @param string $samlAttribute
+     * @param string $propertyName
+     * @return array|null
+     */
+    function parseUserAttribute($samlAttribute = null, $propertyName = null) {
+        if(empty($samlAttribute)) {
+            return null;
+        }
+        if(empty($propertyName)) {
+            return $this->getAttribute($samlAttribute);
+        }
+
+        return $this->{$propertyName} = $this->getAttribute($samlAttribute);
+    }
+
+    /**
+     * Parse the saml attributes and adds it to this user
+     *
+     * @param array $attributes Array of properties which need to be parsed, like this ['email' => 'urn:oid:0.9.2342.19200300.100.1.3']
+     */
+    function parseAttributes($attributes = array()) {
+        foreach($attributes as $propertyName => $samlAttribute) {
+            $this->parseUserAttribute($samlAttribute, $propertyName);
         }
     }
 

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -123,6 +123,53 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('lastError', $saml2->getLastErrorReason());
     }
 
+    public function testGetUserAttribute() {
+        $auth = m::mock('OneLogin_Saml2_Auth');
+        $saml2 = new Saml2Auth($auth);
+
+        $user = $saml2->getSaml2User();
+
+        $auth->shouldReceive('getAttribute')
+            ->with('urn:oid:0.9.2342.19200300.100.1.3')
+            ->andReturn(['test@example.com']);
+
+        $this->assertEquals(['test@example.com'], $user->getAttribute('urn:oid:0.9.2342.19200300.100.1.3'));
+    }
+
+    public function testParseSingleUserAttribute() {
+        $auth = m::mock('OneLogin_Saml2_Auth');
+        $saml2 = new Saml2Auth($auth);
+
+        $user = $saml2->getSaml2User();
+
+        $auth->shouldReceive('getAttribute')
+            ->with('urn:oid:0.9.2342.19200300.100.1.3')
+            ->andReturn(['test@example.com']);
+
+        $user->parseUserAttribute('urn:oid:0.9.2342.19200300.100.1.3', 'email');
+
+        $this->assertEquals($user->email, ['test@example.com']);
+    }
+
+    public function testParseMultipleUserAttributes() {
+        $auth = m::mock('OneLogin_Saml2_Auth');
+        $saml2 = new Saml2Auth($auth);
+
+        $user = $saml2->getSaml2User();
+
+        $auth->shouldReceive('getAttribute')
+            ->twice()
+            ->andReturn(['test@example.com'], ['Test User']);
+
+        $user->parseAttributes([
+            'email' => 'urn:oid:0.9.2342.19200300.100.1.3',
+            'displayName' => 'urn:oid:2.16.840.1.113730.3.1.241'
+        ]);
+
+        $this->assertEquals($user->email, ['test@example.com']);
+        $this->assertEquals($user->displayName, ['Test User']);
+    }
+
 /**
          * Cant test here. It uses Laravel dependencies (eg. config())
          */


### PR DESCRIPTION
Made 3 tests for #97 and bumped the version to 0.9.1

_I know it would be better to set ```$_attributes``` in ```OneLogin_Saml2_Auth```, but this is a private property, and I don't think it's possible to set mock this?_