### PR TITLE
Laravel 5.5 Package Auto-Discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,15 @@
             "Aacotroneo\\Saml2\\": "src/"
         }
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Aacotroneo\\Saml2\\Saml2ServiceProvider"
+            ],
+            "aliases": {
+                "Saml2": "Aacotroneo\\Saml2\\Facades\\Saml2Auth"
+            }
+        }
+    },
     "minimum-stability": "stable"
 }


### PR DESCRIPTION
This enables the new feature of Laravel 5.5 to support package Auto-Discovery, packages will automatically be loaded/registered, so there's no need to add them to ```config/app.php```

See [Taylors' post on Medium](https://medium.com/@taylorotwell/package-auto-discovery-in-laravel-5-5-ea9e3ab20518) and[ his pull request for laravel-debugbar](https://github.com/barryvdh/laravel-debugbar/pull/643)