### PR TITLE
Added ability to load SP and IdP certificate/keys from file (in openssl format)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "ext-openssl": "*",
         "illuminate/support": ">=5.0.0",
         "onelogin/php-saml": "^2.10"
     },

--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -65,6 +65,15 @@ class Saml2ServiceProvider extends ServiceProvider
                 empty($config['sp']['singleLogoutService']['url'])) {
                 $config['sp']['singleLogoutService']['url'] = URL::route('saml_sls');
             }
+            if (strpos($config['sp']['privateKey'], 'file://')===0) {
+                $config['sp']['privateKey'] = $this->extractPkeyFromFile($config['sp']['privateKey']);
+            }
+            if (strpos($config['sp']['x509cert'], 'file://')===0) {
+                $config['sp']['x509cert'] = $this->extractCertFromFile($config['sp']['x509cert']);
+            }
+            if (strpos($config['idp']['x509cert'], 'file://')===0) {
+                $config['idp']['x509cert'] = $this->extractCertFromFile($config['idp']['x509cert']);
+            }
 
             return new OneLogin_Saml2_Auth($config);
         });
@@ -80,4 +89,30 @@ class Saml2ServiceProvider extends ServiceProvider
         return array();
     }
 
+    protected function extractPkeyFromFile($path) {
+        $res = openssl_get_privatekey($path);
+        if (empty($res)) {
+            throw new \Exception('Could not read private key-file at path \'' . $path . '\'');
+        }
+        openssl_pkey_export($res, $pkey);
+        openssl_pkey_free($res);
+        return $this->extractOpensslString($pkey, 'PRIVATE KEY');
+    }
+
+    protected function extractCertFromFile($path) {
+        $res = openssl_x509_read(file_get_contents($path));
+        if (empty($res)) {
+            throw new \Exception('Could not read X509 certificate-file at path \'' . $path . '\'');
+        }
+        openssl_x509_export($res, $cert);
+        openssl_x509_free($res);
+        return $this->extractOpensslString($cert, 'CERTIFICATE');
+    }
+
+    protected function extractOpensslString($keyString, $delimiter) {
+        $keyString = str_replace(["\r", "\n"], "", $keyString);
+        $regex = '/-{5}BEGIN(?:\s|\w)+' . $delimiter . '-{5}\s*(.+?)\s*-{5}END(?:\s|\w)+' . $delimiter . '-{5}/m';
+        preg_match($regex, $keyString, $matches);
+        return empty($matches[1]) ? '' : $matches[1];
+    }
 }


### PR DESCRIPTION
Changes
=====
- Added ability to load SP and IdP certificate/keys from file (in openssl format), by specifying the path in the config-value, prefixed with the "file:://" protocol. Affected config-keys are:
  - $config['sp']['x509cert'']
  - $config['sp']['privateKey'']
  - $config['idp']['x509cert'']
- Added composer dependency to openssl extension.

BC
==
- Assuming values for the configuration keys cannot currently start with the 'file://' protocol prefix, the added detection of this prefix should not entail a BC-break.
- The openssl extension is already required by the onelogin/php-saml dependency., so BC should not be an issue.

Example config
=========
In configfile *config/saml2_settings.php* specify paths with the "file:://" protocol prefix. In this example paths are loaded from the .env environment-file (dotenv lib), with default paths inside the directory *config/resources/saml2*.

```php
return [
    ...
    'sp' => [
        ...
        'x509cert' => 'file://' . env('SAML2_SP_CRT_FILE', dirname(__DIR__) . '/resources/saml2/sp.crt'),
        'privateKey' => 'file://' . env('SAML2_SP_PEM_FILE', dirname(__DIR__) . '/resources/saml2/sp.pem'),
        ...
    ],
    ...
    'idp' => [
        ...
        'x509cert' => 'file://' . env('SAML2_IDP_CRT_FILE', dirname(__DIR__) . '/resources/saml2/idp.crt'),
        ...
    ]
];
```

[edit]

Testing
====

I have tested against laravel 5.3.31 and everything seems to work.