### PR TITLE
updating composer.json dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 composer.phar
 composer.lock
 .DS_Store
+.idea
+

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.4.0",
         "ext-openssl": "*",
         "illuminate/support": ">=5.0.0",
-        "onelogin/php-saml": "3.0.0.x-dev"
+        "onelogin/php-saml": "dev-remove_mcrypt"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*"


### PR DESCRIPTION
Was having an issue with the dev dependency 3.0.0.x-dev in the remove_mcrypt branch dependencies for onelogin/php-saml package. Changing this dependency to the respective remove_mcrypt branch for the dependency fixed the error for me.

Here was the error:
Class 'OneLogin_Saml2_Auth' not found

Maybe this will help someone else. Thanks!