### PR TITLE
Updating Class hints for underlying OneLogin Library

### DIFF
--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -2,9 +2,9 @@
 
 namespace Aacotroneo\Saml2;
 
-use OneLogin_Saml2_Auth;
-use OneLogin_Saml2_Error;
-use OneLogin_Saml2_Utils;
+use OneLogin\Saml2\Auth;
+use OneLogin\Saml2\Error;
+use OneLogin\Saml2\Utils;
 use Aacotroneo\Saml2\Events\Saml2LogoutEvent;
 
 use Log;
@@ -20,7 +20,7 @@ class Saml2Auth
 
     protected $samlAssertion;
 
-    function __construct(OneLogin_Saml2_Auth $auth)
+    function __construct(Auth $auth)
     {
         $this->auth = $auth;
     }
@@ -84,7 +84,7 @@ class Saml2Auth
      *
      * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
      *
-     * @throws OneLogin_Saml2_Error
+     * @throws Error
      */
     function logout($returnTo = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null)
     {
@@ -159,7 +159,7 @@ class Saml2Auth
 
             throw new InvalidArgumentException(
                 'Invalid SP metadata: ' . implode(', ', $errors),
-                OneLogin_Saml2_Error::METADATA_SP_INVALID
+                Error::METADATA_SP_INVALID
             );
         }
     }

--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -1,6 +1,7 @@
 <?php
 namespace Aacotroneo\Saml2;
 
+use OneLogin\Saml2\Auth;
 use OneLogin_Saml2_Auth;
 use URL;
 use Illuminate\Support\ServiceProvider;
@@ -75,7 +76,7 @@ class Saml2ServiceProvider extends ServiceProvider
                 $config['idp']['x509cert'] = $this->extractCertFromFile($config['idp']['x509cert']);
             }
 
-            return new OneLogin_Saml2_Auth($config);
+            return new Auth($config);
         });
     }
 

--- a/src/Aacotroneo/Saml2/Saml2User.php
+++ b/src/Aacotroneo/Saml2/Saml2User.php
@@ -2,7 +2,7 @@
 
 namespace Aacotroneo\Saml2;
 
-use OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Auth;
 
 /**
  * A simple class that represents the user that 'came' inside the saml2 assertion
@@ -14,7 +14,7 @@ class Saml2User
 
     protected $auth;
 
-    function __construct(OneLogin_Saml2_Auth $auth)
+    function __construct(Auth $auth)
     {
         $this->auth = $auth;
     }


### PR DESCRIPTION
version 3.0.0-dev of the OneLogin Library now uses more name-spaced classes, and so currently the remove_mcrypt branch is broken without these updates.

I believe I've gone through the different areas where these classes are used.  If not, let me know!