### PR TITLE
Fixed underlying OneLogin class name to use namespaces

### DIFF
--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -32,7 +32,7 @@ class Saml2ServiceProvider extends ServiceProvider
         ]);
 
         if (config('saml2_settings.proxyVars', false)) {
-            \OneLogin_Saml2_Utils::setProxyVars(true);
+            \OneLogin\Saml2\Utils::setProxyVars(true);
         }
     }
 


### PR DESCRIPTION
Similar to #132, the underlying OneLogin library started using namespaces, but PR #134 missed this change.