### PR TITLE
Renamed config/saml2_settings.php config/saml2.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ For older versions of Laravel (<5.5), you have to add the service provider and a
 ]
 ```
 
-Then publish the config file with `php artisan vendor:publish`. This will add the file `app/config/saml2_settings.php`. This config is handled almost directly by  [OneLogin](https://github.com/onelogin/php-saml) so you may get further references there, but will cover here what's really necessary. There are some other config about routes you may want to check, they are pretty straightforward.
+Then publish the config file with `php artisan vendor:publish`. This will add the file `app/config/saml2.php`. This config is handled almost directly by  [OneLogin](https://github.com/onelogin/php-saml) so you may get further references there, but will cover here what's really necessary. There are some other config about routes you may want to check, they are pretty straightforward.
 
 ### Configuration
 
-Once you publish your saml2_settings.php to your own files, you need to configure your sp and IDP (remote server). The only real difference between this config and the one that OneLogin uses, is that the SP entityId, assertionConsumerService url and singleLogoutService URL are injected by the library. They are taken from routes 'saml_metadata', 'saml_acs' and 'saml_sls' respectively.
+Once you publish your saml2.php to your own files, you need to configure your sp and IDP (remote server). The only real difference between this config and the one that OneLogin uses, is that the SP entityId, assertionConsumerService url and singleLogoutService URL are injected by the library. They are taken from routes 'saml_metadata', 'saml_acs' and 'saml_sls' respectively.
 
 Remember that you don't need to implement those routes, but you'll need to add them to your IDP configuration. For example, if you use simplesamlphp, add the following to /metadata/sp-remote.php
 

--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -48,7 +48,7 @@ class Saml2Controller extends Controller
 
             logger()->error('Saml2 error', $errors);
             session()->flash('saml2_error', $errors);
-            return redirect(config('saml2_settings.errorRoute'));
+            return redirect(config('saml2.errorRoute'));
         }
         $user = $this->saml2Auth->getSaml2User();
 
@@ -60,7 +60,7 @@ class Saml2Controller extends Controller
             return redirect($redirectUrl);
         } else {
 
-            return redirect(config('saml2_settings.loginRoute'));
+            return redirect(config('saml2.loginRoute'));
         }
     }
 
@@ -71,12 +71,12 @@ class Saml2Controller extends Controller
      */
     public function sls()
     {
-        $error = $this->saml2Auth->sls(config('saml2_settings.retrieveParametersFromServer'));
+        $error = $this->saml2Auth->sls(config('saml2.retrieveParametersFromServer'));
         if (!empty($error)) {
             throw new \Exception("Could not log out");
         }
 
-        return redirect(config('saml2_settings.logoutRoute')); //may be set a configurable default
+        return redirect(config('saml2.logoutRoute')); //may be set a configurable default
     }
 
     /**
@@ -97,7 +97,7 @@ class Saml2Controller extends Controller
      */
     public function login()
     {
-        $this->saml2Auth->login(config('saml2_settings.loginRoute'));
+        $this->saml2Auth->login(config('saml2.loginRoute'));
     }
 
 }

--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -23,15 +23,15 @@ class Saml2ServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        if(config('saml2_settings.useRoutes', false) == true ){
+        if(config('saml2.useRoutes', false) == true ){
             include __DIR__ . '/../../routes.php';
         }
 
         $this->publishes([
-            __DIR__.'/../../config/saml2_settings.php' => config_path('saml2_settings.php'),
+            __DIR__.'/../../config/saml2.php' => config_path('saml2.php'),
         ]);
 
-        if (config('saml2_settings.proxyVars', false)) {
+        if (config('saml2.proxyVars', false)) {
             \OneLogin\Saml2\Utils::setProxyVars(true);
         }
     }
@@ -55,7 +55,7 @@ class Saml2ServiceProvider extends ServiceProvider
     protected function registerOneLoginInContainer()
     {
         $this->app->singleton('OneLogin_Saml2_Auth', function ($app) {
-            $config = config('saml2_settings');
+            $config = config('saml2');
             if (empty($config['sp']['entityId'])) {
                 $config['sp']['entityId'] = URL::route('saml_metadata');
             }

--- a/src/routes.php
+++ b/src/routes.php
@@ -2,8 +2,8 @@
 
 
 Route::group([
-    'prefix' => config('saml2_settings.routesPrefix'),
-    'middleware' => config('saml2_settings.routesMiddleware'),
+    'prefix' => config('saml2.routesPrefix'),
+    'middleware' => config('saml2.routesMiddleware'),
 ], function () {
 
     Route::get('/logout', array(


### PR DESCRIPTION
`config/saml2_settings.php` and `config('saml2_settings')` feel kinda redundant, renamed everything to just be `saml2` instead.

I send it to this branch because this feels kind of like the "next version" branch and this is a breaking change (although easy to resolve)