### PR TITLE
add return statement to logout function

### DIFF
--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -81,16 +81,18 @@ class Saml2Auth
      * @param string|null $nameId              The NameID that will be set in the LogoutRequest.
      * @param string|null $sessionIndex        The SessionIndex (taken from the SAML Response in the SSO process).
      * @param string|null $nameIdFormat        The NameID Format will be set in the LogoutRequest.
+     * @param bool        $stay            True if we want to stay (returns the url string) False to redirect
+     * @param string|null $nameIdNameQualifier The NameID NameQualifier will be set in the LogoutRequest.
      *
      * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
      *
      * @throws OneLogin_Saml2_Error
      */
-    function logout($returnTo = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null)
+    function logout($returnTo = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null, $stay = false, $nameIdNameQualifier = null)
     {
         $auth = $this->auth;
 
-        $auth->logout($returnTo, [], $nameId, $sessionIndex, false, $nameIdFormat);
+        return $auth->logout($returnTo, [], $nameId, $sessionIndex, $stay, $nameIdFormat, $nameIdNameQualifier);
     }
 
     /**

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -41,12 +41,14 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
         $expectedSessionIndex = 'session_index_value';
         $expectedNameId = 'name_id_value';
         $expectedNameIdFormat = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified';
+        $expectedStay = true;
+        $expectedNameIdNameQualifier = 'name_id_name_qualifier';
         $auth = m::mock('OneLogin_Saml2_Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('logout')
-            ->with($expectedReturnTo, [], $expectedNameId, $expectedSessionIndex, false, $expectedNameIdFormat)
+            ->with($expectedReturnTo, [], $expectedNameId, $expectedSessionIndex, $expectedStay, $expectedNameIdFormat, $expectedNameIdNameQualifier)
             ->once();
-        $saml2->logout($expectedReturnTo, $expectedNameId, $expectedSessionIndex, $expectedNameIdFormat);
+        $saml2->logout($expectedReturnTo, $expectedNameId, $expectedSessionIndex, $expectedNameIdFormat, $expectedStay, $expectedNameIdNameQualifier);
     }
 
 


### PR DESCRIPTION
Add `$stay` and `$nameIdNameQualifier` support to `Saml2Auth`. These are supported by the OneLogin library.