### PR TITLE
 Update OneLogin SAML toolkit to 3.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.4.0",
         "ext-openssl": "*",
         "illuminate/support": ">=5.0.0",
-        "onelogin/php-saml": "^2.10"
+        "onelogin/php-saml": "^3.0.0"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*"

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -2,9 +2,9 @@
 
 namespace Aacotroneo\Saml2;
 
-use OneLogin_Saml2_Auth;
-use OneLogin_Saml2_Error;
-use OneLogin_Saml2_Utils;
+use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Error as OneLogin_Saml2_Error;
+use OneLogin\Saml2\Utils as OneLogin_Saml2_Utils;
 use Aacotroneo\Saml2\Events\Saml2LogoutEvent;
 
 use Log;

--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -1,7 +1,8 @@
 <?php
 namespace Aacotroneo\Saml2;
 
-use OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Utils as OneLogin_Saml2_Utils;
 use URL;
 use Illuminate\Support\ServiceProvider;
 
@@ -31,7 +32,7 @@ class Saml2ServiceProvider extends ServiceProvider
         ]);
 
         if (config('saml2_settings.proxyVars', false)) {
-            \OneLogin_Saml2_Utils::setProxyVars(true);
+            OneLogin_Saml2_Utils::setProxyVars(true);
         }
     }
 

--- a/src/Aacotroneo/Saml2/Saml2User.php
+++ b/src/Aacotroneo/Saml2/Saml2User.php
@@ -2,7 +2,7 @@
 
 namespace Aacotroneo\Saml2;
 
-use OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
 
 /**
  * A simple class that represents the user that 'came' inside the saml2 assertion

--- a/tests/Saml2/Saml2AuthServiceProviderTest.php
+++ b/tests/Saml2/Saml2AuthServiceProviderTest.php
@@ -5,8 +5,9 @@ namespace Aacotroneo\Saml2;
 
 use App;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class Saml2AuthServiceProviderTest extends \PHPUnit_Framework_TestCase
+class Saml2AuthServiceProviderTest extends TestCase
 {
 
 

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -19,7 +19,7 @@ class Saml2AuthTest extends TestCase
 
     public function testIsAuthenticated()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $auth->shouldReceive('isAuthenticated')->andReturn('return');
@@ -30,7 +30,7 @@ class Saml2AuthTest extends TestCase
 
     public function testLogin()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('login')->once();
         $saml2->login();
@@ -44,7 +44,7 @@ class Saml2AuthTest extends TestCase
         $expectedNameIdFormat = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified';
         $expectedStay = true;
         $expectedNameIdNameQualifier = 'name_id_name_qualifier';
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('logout')
             ->with($expectedReturnTo, [], $expectedNameId, $expectedSessionIndex, $expectedStay, $expectedNameIdFormat, $expectedNameIdNameQualifier)
@@ -55,7 +55,7 @@ class Saml2AuthTest extends TestCase
 
     public function testAcsError()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processResponse')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(array('errors'));
@@ -68,7 +68,7 @@ class Saml2AuthTest extends TestCase
 
     public function testAcsNotAutenticated()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processResponse')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(null);
@@ -81,7 +81,7 @@ class Saml2AuthTest extends TestCase
 
     public function testAcsOK()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processResponse')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(null);
@@ -94,7 +94,7 @@ class Saml2AuthTest extends TestCase
 
     public function testSlsError()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processSLO')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn('errors');
@@ -106,7 +106,7 @@ class Saml2AuthTest extends TestCase
 
     public function testSlsOK()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processSLO')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(null);
@@ -118,7 +118,7 @@ class Saml2AuthTest extends TestCase
 
     public function testCanGetLastError()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $auth->shouldReceive('getLastErrorReason')->andReturn('lastError');
@@ -127,7 +127,7 @@ class Saml2AuthTest extends TestCase
     }
 
     public function testGetUserAttribute() {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $user = $saml2->getSaml2User();
@@ -140,7 +140,7 @@ class Saml2AuthTest extends TestCase
     }
 
     public function testParseSingleUserAttribute() {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $user = $saml2->getSaml2User();
@@ -155,7 +155,7 @@ class Saml2AuthTest extends TestCase
     }
 
     public function testParseMultipleUserAttributes() {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $user = $saml2->getSaml2User();

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -5,8 +5,9 @@ namespace Aacotroneo\Saml2;
 
 use App;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class Saml2AuthTest extends \PHPUnit_Framework_TestCase
+class Saml2AuthTest extends TestCase
 {
 
 


### PR DESCRIPTION
Here is a quick stab at supporting Onelogin SAML toolkit 3.0.

Tests passes and I did some manual tests on my app.

I'm using `use ... as ...` syntax to cut down on number of changes in the pull request - not sure if that is the cleanest approach though.