### PR TITLE
Fix incorrect logout event name in comment

### DIFF
--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -66,7 +66,7 @@ class Saml2Controller extends Controller
 
     /**
      * Process an incoming saml2 logout request.
-     * Fires 'saml2.logoutRequestReceived' event if its valid.
+     * Fires 'Saml2LogoutEvent' event if its valid.
      * This means the user logged out of the SSO infrastructure, you 'should' log him out locally too.
      */
     public function sls()


### PR DESCRIPTION
Small documentation fix in the function comment for `function sls()`.

Logout event was changed in L5 events and cleanup (f358615) from
```php
Event::fire('saml2.logoutRequestReceived');
```
to
```php
Event::fire(new Saml2LogoutEvent());
```