### PR TITLE
Use dependency injection in controller

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.0",
         "ext-openssl": "*",
         "illuminate/support": ">=5.0.0",
         "onelogin/php-saml": "^3.0.0"

--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -1,9 +1,7 @@
 <?php
 namespace Aacotroneo\Saml2;
 
-use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
 use OneLogin\Saml2\Utils as OneLogin_Saml2_Utils;
-use URL;
 use Illuminate\Support\ServiceProvider;
 
 class Saml2ServiceProvider extends ServiceProvider
@@ -44,6 +42,11 @@ class Saml2ServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $this->app->singleton(Saml2Auth::class, function ($app) {
+            $idpName = $app->request->route('idpName');
+            $auth = Saml2Auth::loadOneLoginAuthFromIpdConfig($idpName);
+            return new Saml2Auth($auth);
+        });
     }
 
     /**
@@ -53,7 +56,7 @@ class Saml2ServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return array();
+        return [Saml2Auth::class];
     }
 
 }


### PR DESCRIPTION
So the main idea here is to get rid of the `Saml2Controller` constructor. Instead we register `Saml2Auth` with the service container in `Saml2ServiceProvider` so it can be auto-injected into the controller methods.

Removed the OneLogin\Saml2\Auth import in Saml2Controller.php since it was not in use.

Upped PHP requirement from 5.4 to 5.5 in composer.json because I'm using [class name resolution via `::class`](https://www.php.net/manual/en/migration55.new-features.php#migration55.new-features.class-name)

Fixes #193

<s>**Warning**: I haven't yet fully tested this, since I need to get a working IDP setup first, which I hopefully have later this week. </s> Have now tested this with an IDP. Everything works as it should. Should be ready to merge.