### PR TITLE
Fix static calls in Saml2Auth

### DIFF
--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -4,7 +4,6 @@ namespace Aacotroneo\Saml2;
 
 use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
 use OneLogin\Saml2\Error as OneLogin_Saml2_Error;
-use OneLogin\Saml2\Utils as OneLogin_Saml2_Utils;
 use Aacotroneo\Saml2\Events\Saml2LogoutEvent;
 
 use Log;
@@ -54,13 +53,13 @@ class Saml2Auth
             $config['sp']['singleLogoutService']['url'] = URL::route('saml2_sls', $idpName);
         }
         if (strpos($config['sp']['privateKey'], 'file://')===0) {
-            $config['sp']['privateKey'] = $this->extractPkeyFromFile($config['sp']['privateKey']);
+            $config['sp']['privateKey'] = static::extractPkeyFromFile($config['sp']['privateKey']);
         }
         if (strpos($config['sp']['x509cert'], 'file://')===0) {
-            $config['sp']['x509cert'] = $this->extractCertFromFile($config['sp']['x509cert']);
+            $config['sp']['x509cert'] = static::extractCertFromFile($config['sp']['x509cert']);
         }
         if (strpos($config['idp']['x509cert'], 'file://')===0) {
-            $config['idp']['x509cert'] = $this->extractCertFromFile($config['idp']['x509cert']);
+            $config['idp']['x509cert'] = static::extractCertFromFile($config['idp']['x509cert']);
         }
 
         return new OneLogin_Saml2_Auth($config);
@@ -229,7 +228,7 @@ class Saml2Auth
         }
         openssl_pkey_export($res, $pkey);
         openssl_pkey_free($res);
-        return $this->extractOpensslString($pkey, 'PRIVATE KEY');
+        return static::extractOpensslString($pkey, 'PRIVATE KEY');
     }
 
     protected static function extractCertFromFile($path) {
@@ -239,7 +238,7 @@ class Saml2Auth
         }
         openssl_x509_export($res, $cert);
         openssl_x509_free($res);
-        return $this->extractOpensslString($cert, 'CERTIFICATE');
+        return static::extractOpensslString($cert, 'CERTIFICATE');
     }
 
     protected static function extractOpensslString($keyString, $delimiter) {


### PR DESCRIPTION
`$this` cannot be used in a static context.

Also remove unused `OneLogin_Saml2_Utils` import.