### PR TITLE
Throw an Error For Invalid IdP Name

### DIFF
--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -40,11 +40,11 @@ class Saml2Auth
             throw new \InvalidArgumentException("IDP name required.");
         }
 
-        if (is_null(config('saml2.' . $idpName . '_idp_settings'))) {
+        $config = config('saml2.'.$idpName.'_idp_settings');
+
+        if (is_null($config)) {
             throw new \InvalidArgumentException('"' . $idpName . '" is not a valid IdP.');
         }
-
-        $config = config('saml2.'.$idpName.'_idp_settings');
 
         if (empty($config['sp']['entityId'])) {
             $config['sp']['entityId'] = URL::route('saml2_metadata', $idpName);

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -40,6 +40,10 @@ class Saml2Auth
             throw new \InvalidArgumentException("IDP name required.");
         }
 
+        if (is_null(config('saml2.' . $idpName . '_idp_settings'))) {
+            throw new \InvalidArgumentException('"' . $idpName . '" is not a valid IdP.');
+        }
+
         $config = config('saml2.'.$idpName.'_idp_settings');
 
         if (empty($config['sp']['entityId'])) {


### PR DESCRIPTION
Currently when you make a request to `http://myapp.test/saml2/{idpName}/metadata` or any other route with an IdP that you have not created a config file for you will currently get the following error:
```
Undefined index: privateKey
```
The error is caused by the `loadOneLoginAuthFromIpdConfig` attempting to access the private key of a null configuration. This error is ambiguous so to provide a more detailed error we can add a check in the `loadOneLoginAuthFromIdpConfig` which will check to see if that IdP has a config in the `saml2` config folder.