### PR TITLE
Option to set redirect URL on Saml2LoginEvent

### DIFF
--- a/src/Aacotroneo/Saml2/Events/Saml2LoginEvent.php
+++ b/src/Aacotroneo/Saml2/Events/Saml2LoginEvent.php
@@ -5,10 +5,12 @@ namespace Aacotroneo\Saml2\Events;
 use Aacotroneo\Saml2\Saml2User;
 use Aacotroneo\Saml2\Saml2Auth;
 
-class Saml2LoginEvent extends Saml2Event {
+class Saml2LoginEvent extends Saml2Event
+{
 
     protected $user;
     protected $auth;
+    protected $redirect_url = null;
 
     function __construct($idp, Saml2User $user, Saml2Auth $auth)
     {
@@ -25,5 +27,15 @@ class Saml2LoginEvent extends Saml2Event {
     public function getSaml2Auth()
     {
         return $this->auth;
+    }
+
+    public function getRedirectUrl()
+    {
+        return $this->redirect_url;
+    }
+
+    public function setRedirectUrl($url)
+    {
+        $this->redirect_url = $url;
     }
 }

--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -44,7 +44,11 @@ class Saml2Controller extends Controller
         }
         $user = $saml2Auth->getSaml2User();
 
-        event(new Saml2LoginEvent($idpName, $user, $saml2Auth));
+        $event = event(new Saml2LoginEvent($idpName, $user, $saml2Auth));
+
+        if ($event->getRedirectUrl() !== null) {
+            return redirect($event->getRedirectUrl());
+        }
 
         $redirectUrl = $user->getIntendedUrl();
 


### PR DESCRIPTION
This simply adds the option to set a redirect URL within the Saml2LoginEvent.

That way you can easily set a redirect to another page, e.g. if the user isn't allowed to access the service because of permissions.