### PR TITLE
Add extra check if idp is enabled in settings

### DIFF
--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -40,6 +40,10 @@ class Saml2Auth
             throw new \InvalidArgumentException("IDP name required.");
         }
 
+        if (!in_array($idpName, config('saml2_settings.idpNames', []))) {
+            throw new \InvalidArgumentException("IDP must exist.");
+        }
+
         $config = config('saml2.'.$idpName.'_idp_settings');
 
         if (is_null($config)) {


### PR DESCRIPTION
Right now, the setting `saml_2_setting.idpNames` is not being used at all.
I would like to use this to switch between IDP providers on live, staging and local with a value in the .env
By adding this check, this now can work