### PR TITLE
add metadata validUntil and cacheDuration options to idp settings

### DIFF
--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -200,7 +200,11 @@ class Saml2Auth
     {
         $auth = $this->auth;
         $settings = $auth->getSettings();
-        $metadata = $settings->getSPMetadata();
+
+        $validUntil = isset($settings->getSPData()['validUntil']) ? $settings->getSPData()['validUntil'] : null;
+        $cacheDuration = isset($settings->getSPData()['cacheDuration']) ? $settings->getSPData()['cacheDuration'] : null;
+
+        $metadata = $settings->getSPMetadata(false, $validUntil, $cacheDuration);
         $errors = $settings->validateMetadata($metadata);
 
         if (empty($errors)) {

--- a/src/config/mytestidp1_idp_settings.php
+++ b/src/config/mytestidp1_idp_settings.php
@@ -57,6 +57,18 @@ return $settings = array(
             // Leave blank to use the '{idpName}_sls' route, e.g. 'test_sls'
             'url' => '',
         ),
+
+        /*
+         * Metadata's valid time (timestamp format)
+         * Set to null to use OneLogin's default value
+         */
+        'validUntil' => null,
+
+        /*
+         * Duration of the cache in seconds
+         * Set to null to use OneLogin's default value
+         */
+        'cacheDuration' => null,
     ),
 
     // Identity Provider Data that we want connect with our SP


### PR DESCRIPTION
For some setups of saml2 SSO, metadata with a longer validity than the default provided by Onelogin is required. This is supported by Onelogin now, but not through any settings. I've added it as an option in the IDP settings config. 

Related to #144 